### PR TITLE
Fix(suspensions): Control hardware migration

### DIFF
--- a/clusters/main/kubernetes/apps/freshrss/ks.yaml
+++ b/clusters/main/kubernetes/apps/freshrss/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/apps/freshrss/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/apps/homepage/ks.yaml
+++ b/clusters/main/kubernetes/apps/homepage/ks.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/apps/homepage/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster
-

--- a/clusters/main/kubernetes/apps/kubernetes-dashboard/ks.yaml
+++ b/clusters/main/kubernetes/apps/kubernetes-dashboard/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/apps/kubernetes-dashboard/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/apps/linkwarden/ks.yaml
+++ b/clusters/main/kubernetes/apps/linkwarden/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/apps/linkwarden/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/apps/mealie/ks.yaml
+++ b/clusters/main/kubernetes/apps/mealie/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/apps/mealie/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/apps/snippet-box/ks.yaml
+++ b/clusters/main/kubernetes/apps/snippet-box/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/apps/snippet-box/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/apps/uptime-kuma/ks.yaml
+++ b/clusters/main/kubernetes/apps/uptime-kuma/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/apps/uptime-kuma/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/core/authentik/ks.yaml
+++ b/clusters/main/kubernetes/core/authentik/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/core/authentik/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/core/blocky/app/helm-release.yaml
+++ b/clusters/main/kubernetes/core/blocky/app/helm-release.yaml
@@ -114,8 +114,3 @@ spec:
     configmap:
       dashboard:
         enabled: false
-
-    cnpg:
-      main:
-        cluster:
-          singleNode: true

--- a/clusters/main/kubernetes/core/blocky/ks.yaml
+++ b/clusters/main/kubernetes/core/blocky/ks.yaml
@@ -10,4 +10,3 @@ spec:
   sourceRef:
     kind: GitRepository
     name: cluster
-

--- a/clusters/main/kubernetes/core/external-dns/ks.yaml
+++ b/clusters/main/kubernetes/core/external-dns/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/core/external-dns/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/core/lldap/ks.yaml
+++ b/clusters/main/kubernetes/core/lldap/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/core/lldap/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/core/tailscale/ks.yaml
+++ b/clusters/main/kubernetes/core/tailscale/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/core/tailscale/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/media/calibre-web/ks.yaml
+++ b/clusters/main/kubernetes/media/calibre-web/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/media/calibre-web/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/media/calibre2/ks.yaml
+++ b/clusters/main/kubernetes/media/calibre2/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/media/calibre2/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/media/filebrowser/ks.yaml
+++ b/clusters/main/kubernetes/media/filebrowser/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/media/filebrowser/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/media/kavita/ks.yaml
+++ b/clusters/main/kubernetes/media/kavita/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/media/kavita/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/media/paperless-ngx/ks.yaml
+++ b/clusters/main/kubernetes/media/paperless-ngx/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/media/paperless-ngx/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/media/plex/ks.yaml
+++ b/clusters/main/kubernetes/media/plex/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/media/plex/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/media/stash/ks.yaml
+++ b/clusters/main/kubernetes/media/stash/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/media/stash/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/media/stash2/ks.yaml
+++ b/clusters/main/kubernetes/media/stash2/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/media/stash2/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/metrics/grafana/ks.yaml
+++ b/clusters/main/kubernetes/metrics/grafana/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/metrics/grafana/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster

--- a/clusters/main/kubernetes/networking/unifi/ks.yaml
+++ b/clusters/main/kubernetes/networking/unifi/ks.yaml
@@ -7,6 +7,7 @@ spec:
   interval: 10m
   path: clusters/main/kubernetes/networking/unifi/app
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: cluster


### PR DESCRIPTION
# Manual Pull Request

## 🚀 Summary

<!-- Describe what you've changed and why. Be concise but clear. -->
Add suspensions so I can control when charts are deployed during an imminent hardware changeover. Imminient Longhorn and storage changes so this PR means I can ensure this setup is stable and worked as intended before commencing recovery process.

## 📦 Affected Areas

- [X] HelmRelease
- [X] Kustomization
- [ ] Secrets (SOPS)
- [ ] Cluster Bootstrap / Repos
- [ ] Ingress
- [ ] Monitoring
- [ ] VolSync / Backups
- [ ] CI
- [ ] Other: <!-- Specify -->

---

## ✅ Checklist

- [ ] Secrets encrypted with SOPS and committed as encrypted only
- [ ] No plaintext secrets committed
- [ ] Base domain, hostnames, and URLs are templated correctly
- [ ] Certifcate issuer set correctly
- [ ] Required Helm repositories are defined in `./repositories/helm`
- [ ] Integrations set correctly
- [ ] Chart versions are correct vs upstream
- [ ] Ingress annotations and rules are correct
- [ ] Volsync setup correctly
- [X] Kustomizations reference correct chart and path
- [ ] CI workflows (if applicable) run successfully
- [ ] Namespace is correct and consistent
- [ ] Privileged setup where necessary

---

## 🧠 Notes for Myself

<!-- Leave any reminders, notes, or follow-ups for future you here. -->
